### PR TITLE
Allow unquoted strings for non-empty file paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,10 @@ cd kin/grammar
 bash /usr/local/Cellar/antlr/4.6/bin/antlr4 PBXProj.g4 -Dlanguage=Python2
 ```
 
-The updated file can optionally be copied with this command for testing:
+The updated files can optionally be copied with this command for testing:
 
 ```bash
-cp PBXProjParser.py path/to/site-packages/kin/grammar/PBXProjParser.py
+cp * path/to/site-packages/kin/grammar/
 ```
 
 To run tests, first install the current version of kin by running `pip install .`. Then you can execute `./tests/tester.py` to run all the scenarios we created.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,26 @@ Do you want to contribute?
 
 Feel free to add any useful feature to Kin, we will be glad to improve it with your help.
 
-If you modify the grammar file (`PBXProj.g4`), make sure you compile it using [ANTLR](https://www.antlr.org/). This project is quite old and we are still using Python 2 so, if you have `antlr` installed in your system, go to the `kin/grammar` directory and run `antlr PBXProj.g4 -Dlanguage=Python2` to compile it.
+If you modify the grammar file (`PBXProj.g4`), make sure you compile it using [ANTLR](https://www.antlr.org/). ANLTR version 4.6 can be installed with the following commands (the current version is 4.8 but is not compatible):
+
+```bash
+curl -O https://raw.githubusercontent.com/Homebrew/homebrew-core/92cd4dbae4ae77853e3693b4eb3c24d71855103f/Formula/antlr.rb
+sed -i -e 's/EOS.undent/EOS/g' antlr.rb
+brew install antlr.rb
+```
+
+After changes have been made to the `PBXProj.g4` file it can be compiled with:
+
+```bash
+cd kin/grammar
+bash /usr/local/Cellar/antlr/4.6/bin/antlr4 PBXProj.g4 -Dlanguage=Python2
+```
+
+The updated file can optionally be copied with this command for testing:
+
+```bash
+cp PBXProjParser.py path/to/site-packages/kin/grammar/PBXProjParser.py
+```
 
 To run tests, first install the current version of kin by running `pip install .`. Then you can execute `./tests/tester.py` to run all the scenarios we created.
 

--- a/kin/grammar/PBXProj.g4
+++ b/kin/grammar/PBXProj.g4
@@ -653,7 +653,7 @@ product_ref_group
     ;
 
 project_dir_path
-    : 'projectDirPath' '=' QUOTED_STRING ';'
+    : 'projectDirPath' '=' (QUOTED_STRING|NON_QUOTED_STRING) ';'
     ;
 
 project_references
@@ -662,7 +662,7 @@ project_references
     ;
 
 project_root
-    : 'projectRoot' '=' QUOTED_STRING ';'
+    : 'projectRoot' '=' (QUOTED_STRING|NON_QUOTED_STRING) ';'
     ;
 
 targets
@@ -724,7 +724,7 @@ build_settings
     ;
 
 dst_path
-    : 'dstPath' '=' QUOTED_STRING ';'
+    : 'dstPath' '=' (QUOTED_STRING|NON_QUOTED_STRING) ';'
     ;
 
 dst_subfolder_spec

--- a/kin/grammar/PBXProjParser.py
+++ b/kin/grammar/PBXProjParser.py
@@ -546,7 +546,7 @@ def serializedATN():
         buf.write(u"\u048f\7\6\2\2\u048f\u00e5\3\2\2\2\u0490\u0491\7K\2\2")
         buf.write(u"\u0491\u0492\7\5\2\2\u0492\u0493\7o\2\2\u0493\u0494\7")
         buf.write(u"\6\2\2\u0494\u00e7\3\2\2\2\u0495\u0496\7L\2\2\u0496\u0497")
-        buf.write(u"\7\5\2\2\u0497\u0498\7p\2\2\u0498\u0499\7\6\2\2\u0499")
+        buf.write(u"\7\5\2\2\u0497\u0498\t\2\2\2\u0498\u0499\7\6\2\2\u0499")
         buf.write(u"\u00e9\3\2\2\2\u049a\u049b\7M\2\2\u049b\u049c\7\5\2\2")
         buf.write(u"\u049c\u049d\5\u0124\u0093\2\u049d\u049e\7\6\2\2\u049e")
         buf.write(u"\u04a7\3\2\2\2\u049f\u04a0\7M\2\2\u04a0\u04a1\7\5\2\2")
@@ -554,9 +554,9 @@ def serializedATN():
         buf.write(u"\u04a4\7\60\2\2\u04a4\u04a5\7\6\2\2\u04a5\u04a7\3\2\2")
         buf.write(u"\2\u04a6\u049a\3\2\2\2\u04a6\u049f\3\2\2\2\u04a7\u00eb")
         buf.write(u"\3\2\2\2\u04a8\u04a9\7N\2\2\u04a9\u04aa\7\5\2\2\u04aa")
-        buf.write(u"\u04ab\7p\2\2\u04ab\u04ac\7\6\2\2\u04ac\u00ed\3\2\2\2")
-        buf.write(u"\u04ad\u04ae\7O\2\2\u04ae\u04af\7\5\2\2\u04af\u04b0\5")
-        buf.write(u"\u00aaV\2\u04b0\u04b1\7\6\2\2\u04b1\u00ef\3\2\2\2\u04b2")
+        buf.write(u"\u04ab\t\2\2\2\u04ab\u04ac\7\6\2\2\u04ac\u00ed\3\2\2")
+        buf.write(u"\2\u04ad\u04ae\7O\2\2\u04ae\u04af\7\5\2\2\u04af\u04b0")
+        buf.write(u"\5\u00aaV\2\u04b0\u04b1\7\6\2\2\u04b1\u00ef\3\2\2\2\u04b2")
         buf.write(u"\u04b3\7P\2\2\u04b3\u04b4\7\5\2\2\u04b4\u04b5\5\u00ac")
         buf.write(u"W\2\u04b5\u04b6\7\6\2\2\u04b6\u00f1\3\2\2\2\u04b7\u04b8")
         buf.write(u"\7Q\2\2\u04b8\u04b9\7\5\2\2\u04b9\u04ba\5\u00acW\2\u04ba")
@@ -585,60 +585,60 @@ def serializedATN():
         buf.write(u"\2\u04f4\u04f5\3\2\2\2\u04f5\u04f7\3\2\2\2\u04f6\u04f4")
         buf.write(u"\3\2\2\2\u04f7\u04f8\7\4\2\2\u04f8\u04f9\7\6\2\2\u04f9")
         buf.write(u"\u0109\3\2\2\2\u04fa\u04fb\7]\2\2\u04fb\u04fc\7\5\2\2")
-        buf.write(u"\u04fc\u04fd\7p\2\2\u04fd\u04fe\7\6\2\2\u04fe\u010b\3")
-        buf.write(u"\2\2\2\u04ff\u0500\7^\2\2\u0500\u0501\7\5\2\2\u0501\u0502")
-        buf.write(u"\7q\2\2\u0502\u0503\7\6\2\2\u0503\u010d\3\2\2\2\u0504")
-        buf.write(u"\u0506\5\u0110\u0089\2\u0505\u0504\3\2\2\2\u0506\u0509")
-        buf.write(u"\3\2\2\2\u0507\u0505\3\2\2\2\u0507\u0508\3\2\2\2\u0508")
-        buf.write(u"\u010f\3\2\2\2\u0509\u0507\3\2\2\2\u050a\u050b\7\3\2")
-        buf.write(u"\2\u050b\u050c\7_\2\2\u050c\u050d\7\5\2\2\u050d\u050e")
-        buf.write(u"\7o\2\2\u050e\u050f\7\6\2\2\u050f\u0510\7`\2\2\u0510")
-        buf.write(u"\u0511\7\5\2\2\u0511\u0512\7o\2\2\u0512\u0513\7\6\2\2")
-        buf.write(u"\u0513\u0514\7\4\2\2\u0514\u0515\7/\2\2\u0515\u0111\3")
-        buf.write(u"\2\2\2\u0516\u0517\5\u0124\u0093\2\u0517\u0518\7\5\2")
-        buf.write(u"\2\u0518\u0519\5\u0124\u0093\2\u0519\u051a\7\6\2\2\u051a")
-        buf.write(u"\u0531\3\2\2\2\u051b\u051c\5\u0124\u0093\2\u051c\u051d")
-        buf.write(u"\7\5\2\2\u051d\u051e\7\3\2\2\u051e\u051f\5\u0112\u008a")
-        buf.write(u"\2\u051f\u0520\7\4\2\2\u0520\u0521\7\6\2\2\u0521\u0531")
-        buf.write(u"\3\2\2\2\u0522\u0523\5\u0124\u0093\2\u0523\u0524\7\5")
-        buf.write(u"\2\2\u0524\u052a\7.\2\2\u0525\u0526\5\u0124\u0093\2\u0526")
-        buf.write(u"\u0527\7/\2\2\u0527\u0529\3\2\2\2\u0528\u0525\3\2\2\2")
-        buf.write(u"\u0529\u052c\3\2\2\2\u052a\u0528\3\2\2\2\u052a\u052b")
-        buf.write(u"\3\2\2\2\u052b\u052d\3\2\2\2\u052c\u052a\3\2\2\2\u052d")
-        buf.write(u"\u052e\7\60\2\2\u052e\u052f\7\6\2\2\u052f\u0531\3\2\2")
-        buf.write(u"\2\u0530\u0516\3\2\2\2\u0530\u051b\3\2\2\2\u0530\u0522")
-        buf.write(u"\3\2\2\2\u0531\u0113\3\2\2\2\u0532\u0533\7a\2\2\u0533")
-        buf.write(u"\u0534\7\5\2\2\u0534\u0535\5\u00aaV\2\u0535\u0536\7\6")
-        buf.write(u"\2\2\u0536\u0115\3\2\2\2\u0537\u0538\7b\2\2\u0538\u0539")
-        buf.write(u"\7\5\2\2\u0539\u053a\7q\2\2\u053a\u053b\7\6\2\2\u053b")
-        buf.write(u"\u0117\3\2\2\2\u053c\u053d\7c\2\2\u053d\u053e\7\5\2\2")
-        buf.write(u"\u053e\u053f\t\2\2\2\u053f\u0540\7\6\2\2\u0540\u0119")
-        buf.write(u"\3\2\2\2\u0541\u0542\7d\2\2\u0542\u0543\7\5\2\2\u0543")
-        buf.write(u"\u0547\7\3\2\2\u0544\u0546\5\u0112\u008a\2\u0545\u0544")
-        buf.write(u"\3\2\2\2\u0546\u0549\3\2\2\2\u0547\u0545\3\2\2\2\u0547")
-        buf.write(u"\u0548\3\2\2\2\u0548\u054a\3\2\2\2\u0549\u0547\3\2\2")
-        buf.write(u"\2\u054a\u054b\7\4\2\2\u054b\u054c\7\6\2\2\u054c\u011b")
-        buf.write(u"\3\2\2\2\u054d\u054e\7e\2\2\u054e\u054f\7\5\2\2\u054f")
-        buf.write(u"\u0553\7\3\2\2\u0550\u0552\5\u0112\u008a\2\u0551\u0550")
-        buf.write(u"\3\2\2\2\u0552\u0555\3\2\2\2\u0553\u0551\3\2\2\2\u0553")
-        buf.write(u"\u0554\3\2\2\2\u0554\u0556\3\2\2\2\u0555\u0553\3\2\2")
-        buf.write(u"\2\u0556\u0557\7\4\2\2\u0557\u0558\7\6\2\2\u0558\u011d")
-        buf.write(u"\3\2\2\2\u0559\u055a\7f\2\2\u055a\u055b\7\5\2\2\u055b")
-        buf.write(u"\u055c\7o\2\2\u055c\u055d\7\6\2\2\u055d\u011f\3\2\2\2")
-        buf.write(u"\u055e\u055f\7g\2\2\u055f\u0560\7\5\2\2\u0560\u0561\7")
-        buf.write(u"q\2\2\u0561\u0562\7\6\2\2\u0562\u0121\3\2\2\2\u0563\u0564")
-        buf.write(u"\7h\2\2\u0564\u0565\7\5\2\2\u0565\u0566\5\u0124\u0093")
-        buf.write(u"\2\u0566\u0567\7\6\2\2\u0567\u0123\3\2\2\2\u0568\u0569")
-        buf.write(u"\t\3\2\2\u0569\u0125\3\2\2\2U\u0144\u0148\u014b\u0151")
-        buf.write(u"\u0154\u0158\u015b\u015e\u0162\u0165\u016a\u0177\u017c")
-        buf.write(u"\u0181\u0186\u018b\u0190\u0195\u019a\u019f\u01a4\u01a9")
-        buf.write(u"\u01ae\u01b3\u01b8\u01bd\u01c2\u01c7\u01cc\u01d1\u01e5")
-        buf.write(u"\u01fe\u0209\u020c\u020f\u0212\u0215\u0218\u021b\u021e")
-        buf.write(u"\u0221\u0236\u0239\u023c\u0240\u0243\u025c\u0270\u0274")
-        buf.write(u"\u0297\u029b\u029e\u02a5\u02b9\u02bc\u02c9\u02d4\u02e2")
-        buf.write(u"\u03bb\u03c6\u03d0\u0406\u0409\u040c\u040f\u0413\u0416")
-        buf.write(u"\u0419\u0442\u044c\u044f\u0452\u0455\u0458\u045b\u045e")
-        buf.write(u"\u04a6\u04f4\u0507\u052a\u0530\u0547\u0553")
+        buf.write(u"\u04fc\u04fd\t\2\2\2\u04fd\u04fe\7\6\2\2\u04fe\u010b")
+        buf.write(u"\3\2\2\2\u04ff\u0500\7^\2\2\u0500\u0501\7\5\2\2\u0501")
+        buf.write(u"\u0502\7q\2\2\u0502\u0503\7\6\2\2\u0503\u010d\3\2\2\2")
+        buf.write(u"\u0504\u0506\5\u0110\u0089\2\u0505\u0504\3\2\2\2\u0506")
+        buf.write(u"\u0509\3\2\2\2\u0507\u0505\3\2\2\2\u0507\u0508\3\2\2")
+        buf.write(u"\2\u0508\u010f\3\2\2\2\u0509\u0507\3\2\2\2\u050a\u050b")
+        buf.write(u"\7\3\2\2\u050b\u050c\7_\2\2\u050c\u050d\7\5\2\2\u050d")
+        buf.write(u"\u050e\7o\2\2\u050e\u050f\7\6\2\2\u050f\u0510\7`\2\2")
+        buf.write(u"\u0510\u0511\7\5\2\2\u0511\u0512\7o\2\2\u0512\u0513\7")
+        buf.write(u"\6\2\2\u0513\u0514\7\4\2\2\u0514\u0515\7/\2\2\u0515\u0111")
+        buf.write(u"\3\2\2\2\u0516\u0517\5\u0124\u0093\2\u0517\u0518\7\5")
+        buf.write(u"\2\2\u0518\u0519\5\u0124\u0093\2\u0519\u051a\7\6\2\2")
+        buf.write(u"\u051a\u0531\3\2\2\2\u051b\u051c\5\u0124\u0093\2\u051c")
+        buf.write(u"\u051d\7\5\2\2\u051d\u051e\7\3\2\2\u051e\u051f\5\u0112")
+        buf.write(u"\u008a\2\u051f\u0520\7\4\2\2\u0520\u0521\7\6\2\2\u0521")
+        buf.write(u"\u0531\3\2\2\2\u0522\u0523\5\u0124\u0093\2\u0523\u0524")
+        buf.write(u"\7\5\2\2\u0524\u052a\7.\2\2\u0525\u0526\5\u0124\u0093")
+        buf.write(u"\2\u0526\u0527\7/\2\2\u0527\u0529\3\2\2\2\u0528\u0525")
+        buf.write(u"\3\2\2\2\u0529\u052c\3\2\2\2\u052a\u0528\3\2\2\2\u052a")
+        buf.write(u"\u052b\3\2\2\2\u052b\u052d\3\2\2\2\u052c\u052a\3\2\2")
+        buf.write(u"\2\u052d\u052e\7\60\2\2\u052e\u052f\7\6\2\2\u052f\u0531")
+        buf.write(u"\3\2\2\2\u0530\u0516\3\2\2\2\u0530\u051b\3\2\2\2\u0530")
+        buf.write(u"\u0522\3\2\2\2\u0531\u0113\3\2\2\2\u0532\u0533\7a\2\2")
+        buf.write(u"\u0533\u0534\7\5\2\2\u0534\u0535\5\u00aaV\2\u0535\u0536")
+        buf.write(u"\7\6\2\2\u0536\u0115\3\2\2\2\u0537\u0538\7b\2\2\u0538")
+        buf.write(u"\u0539\7\5\2\2\u0539\u053a\7q\2\2\u053a\u053b\7\6\2\2")
+        buf.write(u"\u053b\u0117\3\2\2\2\u053c\u053d\7c\2\2\u053d\u053e\7")
+        buf.write(u"\5\2\2\u053e\u053f\t\2\2\2\u053f\u0540\7\6\2\2\u0540")
+        buf.write(u"\u0119\3\2\2\2\u0541\u0542\7d\2\2\u0542\u0543\7\5\2\2")
+        buf.write(u"\u0543\u0547\7\3\2\2\u0544\u0546\5\u0112\u008a\2\u0545")
+        buf.write(u"\u0544\3\2\2\2\u0546\u0549\3\2\2\2\u0547\u0545\3\2\2")
+        buf.write(u"\2\u0547\u0548\3\2\2\2\u0548\u054a\3\2\2\2\u0549\u0547")
+        buf.write(u"\3\2\2\2\u054a\u054b\7\4\2\2\u054b\u054c\7\6\2\2\u054c")
+        buf.write(u"\u011b\3\2\2\2\u054d\u054e\7e\2\2\u054e\u054f\7\5\2\2")
+        buf.write(u"\u054f\u0553\7\3\2\2\u0550\u0552\5\u0112\u008a\2\u0551")
+        buf.write(u"\u0550\3\2\2\2\u0552\u0555\3\2\2\2\u0553\u0551\3\2\2")
+        buf.write(u"\2\u0553\u0554\3\2\2\2\u0554\u0556\3\2\2\2\u0555\u0553")
+        buf.write(u"\3\2\2\2\u0556\u0557\7\4\2\2\u0557\u0558\7\6\2\2\u0558")
+        buf.write(u"\u011d\3\2\2\2\u0559\u055a\7f\2\2\u055a\u055b\7\5\2\2")
+        buf.write(u"\u055b\u055c\7o\2\2\u055c\u055d\7\6\2\2\u055d\u011f\3")
+        buf.write(u"\2\2\2\u055e\u055f\7g\2\2\u055f\u0560\7\5\2\2\u0560\u0561")
+        buf.write(u"\7q\2\2\u0561\u0562\7\6\2\2\u0562\u0121\3\2\2\2\u0563")
+        buf.write(u"\u0564\7h\2\2\u0564\u0565\7\5\2\2\u0565\u0566\5\u0124")
+        buf.write(u"\u0093\2\u0566\u0567\7\6\2\2\u0567\u0123\3\2\2\2\u0568")
+        buf.write(u"\u0569\t\3\2\2\u0569\u0125\3\2\2\2U\u0144\u0148\u014b")
+        buf.write(u"\u0151\u0154\u0158\u015b\u015e\u0162\u0165\u016a\u0177")
+        buf.write(u"\u017c\u0181\u0186\u018b\u0190\u0195\u019a\u019f\u01a4")
+        buf.write(u"\u01a9\u01ae\u01b3\u01b8\u01bd\u01c2\u01c7\u01cc\u01d1")
+        buf.write(u"\u01e5\u01fe\u0209\u020c\u020f\u0212\u0215\u0218\u021b")
+        buf.write(u"\u021e\u0221\u0236\u0239\u023c\u0240\u0243\u025c\u0270")
+        buf.write(u"\u0274\u0297\u029b\u029e\u02a5\u02b9\u02bc\u02c9\u02d4")
+        buf.write(u"\u02e2\u03bb\u03c6\u03d0\u0406\u0409\u040c\u040f\u0413")
+        buf.write(u"\u0416\u0419\u0442\u044c\u044f\u0452\u0455\u0458\u045b")
+        buf.write(u"\u045e\u04a6\u04f4\u0507\u052a\u0530\u0547\u0553")
         return buf.getvalue()
 
 
@@ -7824,6 +7824,9 @@ class PBXProjParser ( Parser ):
         def QUOTED_STRING(self):
             return self.getToken(PBXProjParser.QUOTED_STRING, 0)
 
+        def NON_QUOTED_STRING(self):
+            return self.getToken(PBXProjParser.NON_QUOTED_STRING, 0)
+
         def getRuleIndex(self):
             return PBXProjParser.RULE_project_dir_path
 
@@ -7842,6 +7845,7 @@ class PBXProjParser ( Parser ):
 
         localctx = PBXProjParser.Project_dir_pathContext(self, self._ctx, self.state)
         self.enterRule(localctx, 230, self.RULE_project_dir_path)
+        self._la = 0 # Token type
         try:
             self.enterOuterAlt(localctx, 1)
             self.state = 1171
@@ -7849,7 +7853,12 @@ class PBXProjParser ( Parser ):
             self.state = 1172
             self.match(PBXProjParser.T__2)
             self.state = 1173
-            self.match(PBXProjParser.QUOTED_STRING)
+            _la = self._input.LA(1)
+            if not(_la==PBXProjParser.QUOTED_STRING or _la==PBXProjParser.NON_QUOTED_STRING):
+                self._errHandler.recoverInline(self)
+            else:
+                self._errHandler.reportMatch(self)
+                self.consume()
             self.state = 1174
             self.match(PBXProjParser.T__3)
         except RecognitionException as re:
@@ -7942,6 +7951,9 @@ class PBXProjParser ( Parser ):
         def QUOTED_STRING(self):
             return self.getToken(PBXProjParser.QUOTED_STRING, 0)
 
+        def NON_QUOTED_STRING(self):
+            return self.getToken(PBXProjParser.NON_QUOTED_STRING, 0)
+
         def getRuleIndex(self):
             return PBXProjParser.RULE_project_root
 
@@ -7960,6 +7972,7 @@ class PBXProjParser ( Parser ):
 
         localctx = PBXProjParser.Project_rootContext(self, self._ctx, self.state)
         self.enterRule(localctx, 234, self.RULE_project_root)
+        self._la = 0 # Token type
         try:
             self.enterOuterAlt(localctx, 1)
             self.state = 1190
@@ -7967,7 +7980,12 @@ class PBXProjParser ( Parser ):
             self.state = 1191
             self.match(PBXProjParser.T__2)
             self.state = 1192
-            self.match(PBXProjParser.QUOTED_STRING)
+            _la = self._input.LA(1)
+            if not(_la==PBXProjParser.QUOTED_STRING or _la==PBXProjParser.NON_QUOTED_STRING):
+                self._errHandler.recoverInline(self)
+            else:
+                self._errHandler.reportMatch(self)
+                self.consume()
             self.state = 1193
             self.match(PBXProjParser.T__3)
         except RecognitionException as re:
@@ -8640,6 +8658,9 @@ class PBXProjParser ( Parser ):
         def QUOTED_STRING(self):
             return self.getToken(PBXProjParser.QUOTED_STRING, 0)
 
+        def NON_QUOTED_STRING(self):
+            return self.getToken(PBXProjParser.NON_QUOTED_STRING, 0)
+
         def getRuleIndex(self):
             return PBXProjParser.RULE_dst_path
 
@@ -8658,6 +8679,7 @@ class PBXProjParser ( Parser ):
 
         localctx = PBXProjParser.Dst_pathContext(self, self._ctx, self.state)
         self.enterRule(localctx, 264, self.RULE_dst_path)
+        self._la = 0 # Token type
         try:
             self.enterOuterAlt(localctx, 1)
             self.state = 1272
@@ -8665,7 +8687,12 @@ class PBXProjParser ( Parser ):
             self.state = 1273
             self.match(PBXProjParser.T__2)
             self.state = 1274
-            self.match(PBXProjParser.QUOTED_STRING)
+            _la = self._input.LA(1)
+            if not(_la==PBXProjParser.QUOTED_STRING or _la==PBXProjParser.NON_QUOTED_STRING):
+                self._errHandler.recoverInline(self)
+            else:
+                self._errHandler.reportMatch(self)
+                self.consume()
             self.state = 1275
             self.match(PBXProjParser.T__3)
         except RecognitionException as re:

--- a/tests/ok/003.pbxproj
+++ b/tests/ok/003.pbxproj
@@ -1,0 +1,710 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		4073733CAB3A0DFF92509CB4 /* Pods_MitsumoriUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 50207757D99BA58B73384B1C /* Pods_MitsumoriUITests.framework */; };
+		40B8192350A5E6A7FD028AF1 /* Pods_Mitsumori.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5E9C8B51DFD24BD194B40CE8 /* Pods_Mitsumori.framework */; };
+		490970611C16D9A900200801 /* UIViewTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490970601C16D9A900200801 /* UIViewTransform.swift */; };
+		495413B61C1424A20071F4A0 /* CardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 495413B51C1424A20071F4A0 /* CardViewModel.swift */; };
+		4959011B1C58F8AB000EE944 /* CustomView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4959011A1C58F8AB000EE944 /* CustomView.swift */; };
+		4973659F1C19BC6E00837617 /* MitsumoriUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4973659E1C19BC6E00837617 /* MitsumoriUITests.swift */; };
+		497365A91C19BD5A00837617 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 497365A81C19BD5A00837617 /* Nimble.framework */; };
+		49C4EEDE1C5E152800B38CD9 /* SelectedCardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C4EEDD1C5E152800B38CD9 /* SelectedCardViewModel.swift */; };
+		49F0E1DF1C1B28FF0074B5B7 /* SnapshotHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F0E1DE1C1B28FF0074B5B7 /* SnapshotHelper.swift */; };
+		49F0E1E11C1B300E0074B5B7 /* SnapshotCapturer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F0E1E01C1B300E0074B5B7 /* SnapshotCapturer.swift */; };
+		49F4A5891C583A95007C84A1 /* Animation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F4A5881C583A95007C84A1 /* Animation.swift */; };
+		49F4A58B1C583AB3007C84A1 /* Transform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F4A58A1C583AB3007C84A1 /* Transform.swift */; };
+		49F4A58D1C583AE3007C84A1 /* CGPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F4A58C1C583AE3007C84A1 /* CGPoint.swift */; };
+		49F4A58F1C583AF3007C84A1 /* CGSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F4A58E1C583AF3007C84A1 /* CGSize.swift */; };
+		49F4A5911C583B0C007C84A1 /* Card.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F4A5901C583B0C007C84A1 /* Card.swift */; };
+		49F4A5931C583B4C007C84A1 /* Double.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F4A5921C583B4C007C84A1 /* Double.swift */; };
+		49F4A5951C583B61007C84A1 /* FrontCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F4A5941C583B61007C84A1 /* FrontCardView.swift */; };
+		49F4A5971C583B94007C84A1 /* FrontCardView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 49F4A5961C583B94007C84A1 /* FrontCardView.xib */; };
+		49F4A5991C583BAF007C84A1 /* Math.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F4A5981C583BAF007C84A1 /* Math.swift */; };
+		49F4A59F1C583D88007C84A1 /* RotateRevealSelectedCardAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F4A59E1C583D88007C84A1 /* RotateRevealSelectedCardAnimation.swift */; };
+		49F4A5A11C583DAE007C84A1 /* RotateSelectCardAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F4A5A01C583DAE007C84A1 /* RotateSelectCardAnimation.swift */; };
+		49F4A5A31C583DD8007C84A1 /* SlideToSideRestoreAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F4A5A21C583DD8007C84A1 /* SlideToSideRestoreAnimation.swift */; };
+		49FBBF921C10C2A200A1A4BB /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49FBBF911C10C2A200A1A4BB /* AppDelegate.swift */; };
+		49FBBF971C10C2A200A1A4BB /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 49FBBF951C10C2A200A1A4BB /* Main.storyboard */; };
+		49FBBF991C10C2A200A1A4BB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 49FBBF981C10C2A200A1A4BB /* Assets.xcassets */; };
+		49FBBF9C1C10C2A200A1A4BB /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 49FBBF9A1C10C2A200A1A4BB /* LaunchScreen.storyboard */; };
+		49FBBFC01C10D05800A1A4BB /* CardCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49FBBFBF1C10D05800A1A4BB /* CardCollectionViewCell.swift */; };
+		49FBBFC41C10EBE600A1A4BB /* CardsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49FBBFC31C10EBE600A1A4BB /* CardsViewController.swift */; };
+		49FBBFC81C10FB9C00A1A4BB /* UIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49FBBFC71C10FB9C00A1A4BB /* UIView.swift */; };
+		EBFE74EE1C4900D000B7B646 /* BackCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBFE74ED1C4900D000B7B646 /* BackCardView.swift */; };
+		EBFE74F01C4900EB00B7B646 /* BackCardView.xib in Resources */ = {isa = PBXBuildFile; fileRef = EBFE74EF1C4900EB00B7B646 /* BackCardView.xib */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		497365A11C19BC6E00837617 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 49FBBF861C10C2A200A1A4BB /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 49FBBF8D1C10C2A200A1A4BB;
+			remoteInfo = Mitsumori;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		0D90B4EBF4714D2C4F8805EE /* Pods_MitsumoriTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MitsumoriTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		274E42B0193BA6FEFA8FD71C /* Pods-MitsumoriUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MitsumoriUITests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MitsumoriUITests/Pods-MitsumoriUITests.debug.xcconfig"; sourceTree = "<group>"; };
+		2757E033CFB59572DA4E60B3 /* Pods-MitsumoriUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MitsumoriUITests.release.xcconfig"; path = "Pods/Target Support Files/Pods-MitsumoriUITests/Pods-MitsumoriUITests.release.xcconfig"; sourceTree = "<group>"; };
+		490970601C16D9A900200801 /* UIViewTransform.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIViewTransform.swift; sourceTree = "<group>"; };
+		495413B51C1424A20071F4A0 /* CardViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardViewModel.swift; sourceTree = "<group>"; };
+		4959011A1C58F8AB000EE944 /* CustomView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomView.swift; sourceTree = "<group>"; };
+		4973659C1C19BC6E00837617 /* MitsumoriUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MitsumoriUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		4973659E1C19BC6E00837617 /* MitsumoriUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MitsumoriUITests.swift; sourceTree = "<group>"; };
+		497365A01C19BC6E00837617 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		497365A61C19BC9500837617 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = "Pods/../build/Debug-iphoneos/Nimble.framework"; sourceTree = "<group>"; };
+		497365A81C19BD5A00837617 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = "Pods/../build/Debug-iphoneos/Nimble.framework"; sourceTree = "<group>"; };
+		49C4EEDD1C5E152800B38CD9 /* SelectedCardViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SelectedCardViewModel.swift; sourceTree = "<group>"; };
+		49F0E1DE1C1B28FF0074B5B7 /* SnapshotHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SnapshotHelper.swift; sourceTree = "<group>"; };
+		49F0E1E01C1B300E0074B5B7 /* SnapshotCapturer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SnapshotCapturer.swift; sourceTree = "<group>"; };
+		49F4A5881C583A95007C84A1 /* Animation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Animation.swift; sourceTree = "<group>"; };
+		49F4A58A1C583AB3007C84A1 /* Transform.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Transform.swift; sourceTree = "<group>"; };
+		49F4A58C1C583AE3007C84A1 /* CGPoint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CGPoint.swift; sourceTree = "<group>"; };
+		49F4A58E1C583AF3007C84A1 /* CGSize.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CGSize.swift; sourceTree = "<group>"; };
+		49F4A5901C583B0C007C84A1 /* Card.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Card.swift; sourceTree = "<group>"; };
+		49F4A5921C583B4C007C84A1 /* Double.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Double.swift; sourceTree = "<group>"; };
+		49F4A5941C583B61007C84A1 /* FrontCardView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FrontCardView.swift; sourceTree = "<group>"; };
+		49F4A5961C583B94007C84A1 /* FrontCardView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = FrontCardView.xib; sourceTree = "<group>"; };
+		49F4A5981C583BAF007C84A1 /* Math.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Math.swift; sourceTree = "<group>"; };
+		49F4A59E1C583D88007C84A1 /* RotateRevealSelectedCardAnimation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RotateRevealSelectedCardAnimation.swift; sourceTree = "<group>"; };
+		49F4A5A01C583DAE007C84A1 /* RotateSelectCardAnimation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RotateSelectCardAnimation.swift; sourceTree = "<group>"; };
+		49F4A5A21C583DD8007C84A1 /* SlideToSideRestoreAnimation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SlideToSideRestoreAnimation.swift; sourceTree = "<group>"; };
+		49FBBF8E1C10C2A200A1A4BB /* Mitsumori.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Mitsumori.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		49FBBF911C10C2A200A1A4BB /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		49FBBF961C10C2A200A1A4BB /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		49FBBF981C10C2A200A1A4BB /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		49FBBF9B1C10C2A200A1A4BB /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		49FBBF9D1C10C2A200A1A4BB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		49FBBFBF1C10D05800A1A4BB /* CardCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardCollectionViewCell.swift; sourceTree = "<group>"; };
+		49FBBFC31C10EBE600A1A4BB /* CardsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardsViewController.swift; sourceTree = "<group>"; };
+		49FBBFC71C10FB9C00A1A4BB /* UIView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIView.swift; sourceTree = "<group>"; };
+		50207757D99BA58B73384B1C /* Pods_MitsumoriUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MitsumoriUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		5E9C8B51DFD24BD194B40CE8 /* Pods_Mitsumori.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Mitsumori.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		83CD4CEBE1B7A02772169FE5 /* Pods-Mitsumori.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Mitsumori.release.xcconfig"; path = "Pods/Target Support Files/Pods-Mitsumori/Pods-Mitsumori.release.xcconfig"; sourceTree = "<group>"; };
+		EBFE74ED1C4900D000B7B646 /* BackCardView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackCardView.swift; sourceTree = "<group>"; };
+		EBFE74EF1C4900EB00B7B646 /* BackCardView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = BackCardView.xib; sourceTree = "<group>"; };
+		F128C4D0067FEE87B2756BC4 /* Pods-Mitsumori.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Mitsumori.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Mitsumori/Pods-Mitsumori.debug.xcconfig"; sourceTree = "<group>"; };
+		FR_FE870E28DC2371E7ACA886F03F460581 /* Something.xcconfig */ = {isa = PBXFileReference; explicitFileType = text.xcconfig; name = "Something.xcconfig"; path = "Configurations/Something.xcconfig"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		497365991C19BC6E00837617 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				497365A91C19BD5A00837617 /* Nimble.framework in Frameworks */,
+				4073733CAB3A0DFF92509CB4 /* Pods_MitsumoriUITests.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		49FBBF8B1C10C2A200A1A4BB /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				40B8192350A5E6A7FD028AF1 /* Pods_Mitsumori.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		3F7D3EDF02E1003A4134947D /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				274E42B0193BA6FEFA8FD71C /* Pods-MitsumoriUITests.debug.xcconfig */,
+				2757E033CFB59572DA4E60B3 /* Pods-MitsumoriUITests.release.xcconfig */,
+				F128C4D0067FEE87B2756BC4 /* Pods-Mitsumori.debug.xcconfig */,
+				83CD4CEBE1B7A02772169FE5 /* Pods-Mitsumori.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
+		4973659D1C19BC6E00837617 /* MitsumoriUITests */ = {
+			isa = PBXGroup;
+			children = (
+				49F0E1DE1C1B28FF0074B5B7 /* SnapshotHelper.swift */,
+				4973659E1C19BC6E00837617 /* MitsumoriUITests.swift */,
+				497365A01C19BC6E00837617 /* Info.plist */,
+				49F0E1E01C1B300E0074B5B7 /* SnapshotCapturer.swift */,
+			);
+			path = MitsumoriUITests;
+			sourceTree = "<group>";
+		};
+		49F4A5811C583958007C84A1 /* Animation */ = {
+			isa = PBXGroup;
+			children = (
+				49F4A5881C583A95007C84A1 /* Animation.swift */,
+				49F4A59E1C583D88007C84A1 /* RotateRevealSelectedCardAnimation.swift */,
+				49F4A5A01C583DAE007C84A1 /* RotateSelectCardAnimation.swift */,
+				49F4A5A21C583DD8007C84A1 /* SlideToSideRestoreAnimation.swift */,
+			);
+			name = Animation;
+			sourceTree = "<group>";
+		};
+		49F4A5821C583998007C84A1 /* Extension */ = {
+			isa = PBXGroup;
+			children = (
+				49F4A58C1C583AE3007C84A1 /* CGPoint.swift */,
+				49F4A58E1C583AF3007C84A1 /* CGSize.swift */,
+				49F4A5921C583B4C007C84A1 /* Double.swift */,
+				49FBBFC71C10FB9C00A1A4BB /* UIView.swift */,
+				490970601C16D9A900200801 /* UIViewTransform.swift */,
+				49F4A5981C583BAF007C84A1 /* Math.swift */,
+			);
+			name = Extension;
+			sourceTree = "<group>";
+		};
+		49F4A5831C5839A1007C84A1 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				49F4A5901C583B0C007C84A1 /* Card.swift */,
+			);
+			name = Model;
+			sourceTree = "<group>";
+		};
+		49F4A5841C5839B0007C84A1 /* Storyboard */ = {
+			isa = PBXGroup;
+			children = (
+				49FBBF9A1C10C2A200A1A4BB /* LaunchScreen.storyboard */,
+				49FBBF951C10C2A200A1A4BB /* Main.storyboard */,
+			);
+			name = Storyboard;
+			sourceTree = "<group>";
+		};
+		49F4A5851C5839B7007C84A1 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				EBFE74ED1C4900D000B7B646 /* BackCardView.swift */,
+				EBFE74EF1C4900EB00B7B646 /* BackCardView.xib */,
+				49FBBFBF1C10D05800A1A4BB /* CardCollectionViewCell.swift */,
+				4959011A1C58F8AB000EE944 /* CustomView.swift */,
+				49F4A5941C583B61007C84A1 /* FrontCardView.swift */,
+				49F4A5961C583B94007C84A1 /* FrontCardView.xib */,
+				49F4A58A1C583AB3007C84A1 /* Transform.swift */,
+			);
+			name = View;
+			sourceTree = "<group>";
+		};
+		49F4A5861C583A12007C84A1 /* ViewController */ = {
+			isa = PBXGroup;
+			children = (
+				49FBBFC31C10EBE600A1A4BB /* CardsViewController.swift */,
+			);
+			name = ViewController;
+			sourceTree = "<group>";
+		};
+		49F4A5871C583A25007C84A1 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				495413B51C1424A20071F4A0 /* CardViewModel.swift */,
+				49C4EEDD1C5E152800B38CD9 /* SelectedCardViewModel.swift */,
+			);
+			name = ViewModel;
+			sourceTree = "<group>";
+		};
+		49FBBF851C10C2A200A1A4BB = {
+			isa = PBXGroup;
+			children = (
+				49FBBF901C10C2A200A1A4BB /* Mitsumori */,
+				4973659D1C19BC6E00837617 /* MitsumoriUITests */,
+				49FBBF8F1C10C2A200A1A4BB /* Products */,
+				3F7D3EDF02E1003A4134947D /* Pods */,
+				843513CC76A2B252F7CE6020 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		49FBBF8F1C10C2A200A1A4BB /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				49FBBF8E1C10C2A200A1A4BB /* Mitsumori.app */,
+				4973659C1C19BC6E00837617 /* MitsumoriUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		49FBBF901C10C2A200A1A4BB /* Mitsumori */ = {
+			isa = PBXGroup;
+			children = (
+				49FBBF981C10C2A200A1A4BB /* Assets.xcassets */,
+				49FBBF9D1C10C2A200A1A4BB /* Info.plist */,
+				49F4A5811C583958007C84A1 /* Animation */,
+				49F4A5821C583998007C84A1 /* Extension */,
+				49F4A5831C5839A1007C84A1 /* Model */,
+				49F4A5841C5839B0007C84A1 /* Storyboard */,
+				49F4A5851C5839B7007C84A1 /* View */,
+				49F4A5861C583A12007C84A1 /* ViewController */,
+				49F4A5871C583A25007C84A1 /* ViewModel */,
+				49FBBF911C10C2A200A1A4BB /* AppDelegate.swift */,
+			);
+			path = Mitsumori;
+			sourceTree = "<group>";
+		};
+		843513CC76A2B252F7CE6020 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				497365A81C19BD5A00837617 /* Nimble.framework */,
+				497365A61C19BC9500837617 /* Nimble.framework */,
+				0D90B4EBF4714D2C4F8805EE /* Pods_MitsumoriTests.framework */,
+				50207757D99BA58B73384B1C /* Pods_MitsumoriUITests.framework */,
+				5E9C8B51DFD24BD194B40CE8 /* Pods_Mitsumori.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		G_78452DDA02BFEF5D6BA29AEFB4B1266A /* Configurations */ = {
+			isa = PBXGroup;
+			children = (
+				FR_FE870E28DC2371E7ACA886F03F460581 /* Something.xcconfig */,
+			);
+			name = Configurations;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		4973659B1C19BC6E00837617 /* MitsumoriUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 497365A31C19BC6E00837617 /* Build configuration list for PBXNativeTarget "MitsumoriUITests" */;
+			buildPhases = (
+				0D338338AD469905FE45C5D7 /* Check Pods Manifest.lock */,
+				497365981C19BC6E00837617 /* Sources */,
+				497365991C19BC6E00837617 /* Frameworks */,
+				4973659A1C19BC6E00837617 /* Resources */,
+				77A1B287EDAA82F36793B49B /* Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				497365A21C19BC6E00837617 /* PBXTargetDependency */,
+			);
+			name = MitsumoriUITests;
+			productName = MitsumoriUITests;
+			productReference = 4973659C1C19BC6E00837617 /* MitsumoriUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+		49FBBF8D1C10C2A200A1A4BB /* Mitsumori */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 49FBBFB61C10C2A200A1A4BB /* Build configuration list for PBXNativeTarget "Mitsumori" */;
+			buildPhases = (
+				B413487ECFAF19CC720F6703 /* Check Pods Manifest.lock */,
+				49FBBF8A1C10C2A200A1A4BB /* Sources */,
+				49FBBF8B1C10C2A200A1A4BB /* Frameworks */,
+				49FBBF8C1C10C2A200A1A4BB /* Resources */,
+				E09A62F1C2781CCB49DC3900 /* Embed Pods Frameworks */,
+				19FA3CFC97A494716FCCD298 /* Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Mitsumori;
+			productName = Mitsumori;
+			productReference = 49FBBF8E1C10C2A200A1A4BB /* Mitsumori.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		49FBBF861C10C2A200A1A4BB /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				DefaultBuildSystemTypeForWorkspace = Original;
+				LastSwiftUpdateCheck = 0720;
+				LastUpgradeCheck = 0710;
+				ORGANIZATIONNAME = Karumi;
+				TargetAttributes = {
+					4973659B1C19BC6E00837617 = {
+						CreatedOnToolsVersion = 7.2;
+						TestTargetID = 49FBBF8D1C10C2A200A1A4BB;
+					};
+					49FBBF8D1C10C2A200A1A4BB = {
+						CreatedOnToolsVersion = 7.1.1;
+						DevelopmentTeam = BD48FG9BMV;
+					};
+				};
+			};
+			buildConfigurationList = 49FBBF891C10C2A200A1A4BB /* Build configuration list for PBXProject "Mitsumori" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 49FBBF851C10C2A200A1A4BB;
+			productRefGroup = 49FBBF8F1C10C2A200A1A4BB /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				49FBBF8D1C10C2A200A1A4BB /* Mitsumori */,
+				4973659B1C19BC6E00837617 /* MitsumoriUITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		4973659A1C19BC6E00837617 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		49FBBF8C1C10C2A200A1A4BB /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				49F4A5971C583B94007C84A1 /* FrontCardView.xib in Resources */,
+				49FBBF9C1C10C2A200A1A4BB /* LaunchScreen.storyboard in Resources */,
+				49FBBF991C10C2A200A1A4BB /* Assets.xcassets in Resources */,
+				49FBBF971C10C2A200A1A4BB /* Main.storyboard in Resources */,
+				EBFE74F01C4900EB00B7B646 /* BackCardView.xib in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		0D338338AD469905FE45C5D7 /* Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		19FA3CFC97A494716FCCD298 /* Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Copy Pods Resources";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Mitsumori/Pods-Mitsumori-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		77A1B287EDAA82F36793B49B /* Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = ();
+			inputPaths = (
+			);
+			name = "Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MitsumoriUITests/Pods-MitsumoriUITests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		B413487ECFAF19CC720F6703 /* Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		E09A62F1C2781CCB49DC3900 /* Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Mitsumori/Pods-Mitsumori-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		497365981C19BC6E00837617 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				49F0E1E11C1B300E0074B5B7 /* SnapshotCapturer.swift in Sources */,
+				4973659F1C19BC6E00837617 /* MitsumoriUITests.swift in Sources */,
+				49F0E1DF1C1B28FF0074B5B7 /* SnapshotHelper.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		49FBBF8A1C10C2A200A1A4BB /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				49F4A58D1C583AE3007C84A1 /* CGPoint.swift in Sources */,
+				49FBBFC81C10FB9C00A1A4BB /* UIView.swift in Sources */,
+				49FBBFC41C10EBE600A1A4BB /* CardsViewController.swift in Sources */,
+				49F4A58B1C583AB3007C84A1 /* Transform.swift in Sources */,
+				49F4A5911C583B0C007C84A1 /* Card.swift in Sources */,
+				49F4A58F1C583AF3007C84A1 /* CGSize.swift in Sources */,
+				49F4A5931C583B4C007C84A1 /* Double.swift in Sources */,
+				4959011B1C58F8AB000EE944 /* CustomView.swift in Sources */,
+				490970611C16D9A900200801 /* UIViewTransform.swift in Sources */,
+				EBFE74EE1C4900D000B7B646 /* BackCardView.swift in Sources */,
+				495413B61C1424A20071F4A0 /* CardViewModel.swift in Sources */,
+				49FBBF921C10C2A200A1A4BB /* AppDelegate.swift in Sources */,
+				49F4A5891C583A95007C84A1 /* Animation.swift in Sources */,
+				49C4EEDE1C5E152800B38CD9 /* SelectedCardViewModel.swift in Sources */,
+				49F4A5A11C583DAE007C84A1 /* RotateSelectCardAnimation.swift in Sources */,
+				49FBBFC01C10D05800A1A4BB /* CardCollectionViewCell.swift in Sources */,
+				49F4A5951C583B61007C84A1 /* FrontCardView.swift in Sources */,
+				49F4A59F1C583D88007C84A1 /* RotateRevealSelectedCardAnimation.swift in Sources */,
+				49F4A5A31C583DD8007C84A1 /* SlideToSideRestoreAnimation.swift in Sources */,
+				49F4A5991C583BAF007C84A1 /* Math.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		497365A21C19BC6E00837617 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 49FBBF8D1C10C2A200A1A4BB /* Mitsumori */;
+			targetProxy = 497365A11C19BC6E00837617 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		49FBBF951C10C2A200A1A4BB /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				49FBBF961C10C2A200A1A4BB /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		49FBBF9A1C10C2A200A1A4BB /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				49FBBF9B1C10C2A200A1A4BB /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		497365A41C19BC6E00837617 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 274E42B0193BA6FEFA8FD71C /* Pods-MitsumoriUITests.debug.xcconfig */;
+			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/build/Debug-iphoneos",
+				);
+				INFOPLIST_FILE = MitsumoriUITests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.karumi.MitsumoriUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_TARGET_NAME = Mitsumori;
+				USES_XCTRUNNER = YES;
+			};
+			name = Debug;
+		};
+		497365A51C19BC6E00837617 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 2757E033CFB59572DA4E60B3 /* Pods-MitsumoriUITests.release.xcconfig */;
+			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/build/Debug-iphoneos",
+				);
+				INFOPLIST_FILE = MitsumoriUITests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.karumi.MitsumoriUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_TARGET_NAME = Mitsumori;
+				USES_XCTRUNNER = YES;
+			};
+			name = Release;
+		};
+		49FBBFB41C10C2A200A1A4BB /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		49FBBFB51C10C2A200A1A4BB /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Distribution: Gokarumi S.L. (BD48FG9BMV)";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		49FBBFB71C10C2A200A1A4BB /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = F128C4D0067FEE87B2756BC4 /* Pods-Mitsumori.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 10;
+				INFOPLIST_FILE = Mitsumori/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.karumi.mitsumori;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		49FBBFB81C10C2A200A1A4BB /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 83CD4CEBE1B7A02772169FE5 /* Pods-Mitsumori.release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 10;
+				INFOPLIST_FILE = Mitsumori/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.karumi.mitsumori;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		497365A31C19BC6E00837617 /* Build configuration list for PBXNativeTarget "MitsumoriUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				497365A41C19BC6E00837617 /* Debug */,
+				497365A51C19BC6E00837617 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "Foo Release";
+		};
+		49FBBF891C10C2A200A1A4BB /* Build configuration list for PBXProject "Mitsumori" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				49FBBFB41C10C2A200A1A4BB /* Debug */,
+				49FBBFB51C10C2A200A1A4BB /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		49FBBFB61C10C2A200A1A4BB /* Build configuration list for PBXNativeTarget "Mitsumori" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				49FBBFB71C10C2A200A1A4BB /* Debug */,
+				49FBBFB81C10C2A200A1A4BB /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 49FBBF861C10C2A200A1A4BB /* Project object */;
+}

--- a/tests/ok/003.pbxproj
+++ b/tests/ok/003.pbxproj
@@ -50,6 +50,28 @@
 		};
 /* End PBXContainerItemProxy section */
 
+/* Begin PBXCopyFilesBuildPhase section */
+		A17EE1AB211A62BB00811AE1 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A1C7CBAA2196521000315028 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = Test;
+			dstSubfolderSpec = 7;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
 		0D90B4EBF4714D2C4F8805EE /* Pods_MitsumoriTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MitsumoriTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		274E42B0193BA6FEFA8FD71C /* Pods-MitsumoriUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MitsumoriUITests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MitsumoriUITests/Pods-MitsumoriUITests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -341,8 +363,8 @@
 			);
 			mainGroup = 49FBBF851C10C2A200A1A4BB;
 			productRefGroup = 49FBBF8F1C10C2A200A1A4BB /* Products */;
-			projectDirPath = "";
-			projectRoot = "";
+			projectDirPath = Test;
+			projectRoot = Test;
 			targets = (
 				49FBBF8D1C10C2A200A1A4BB /* Mitsumori */,
 				4973659B1C19BC6E00837617 /* MitsumoriUITests */,


### PR DESCRIPTION
This pull request aims to reduce false positives for file paths when Xcode saves non-empty file paths unquoted.

Testing with Xcode 12.0.1 (12A7300) the following keys had quotes removed for non-empty strings if the project file had any changes when closing a project:
- `dstPath`
- `projectRoot`
- `projectDirPath`

Parser files generated from ANTLR 4.8 cause exceptions, version 4.6 works with these steps though:

```
wget https://raw.githubusercontent.com/Homebrew/homebrew-core/92cd4dbae4ae77853e3693b4eb3c24d71855103f/Formula/antlr.rb
sed -i -e 's/EOS.undent/EOS/g' antlr.rb
brew install antlr.rb
cd ~/Kin/kin/grammar
```

Make the changes to the `PBXProj.g4` file.

```
bash /usr/local/Cellar/antlr/4.6/bin/antlr4 PBXProj.g4 -Dlanguage=Python2
```

After the ANTLR changes are made, copy the `PBXProjParser.py` file to the installation of `kin`, in this case [asdf](https://github.com/asdf-vm/asdf):

```
cp ~/Kin/kin/grammar/PBXProjParser.py ~/.asdf/installs/python/2.7.18/lib/python2.7/site-packages/kin/grammar/PBXProjParser.py
```
