### PR TITLE
Allow unquoted strings for shellScript keys

### DIFF
--- a/kin/grammar/PBXProj.g4
+++ b/kin/grammar/PBXProj.g4
@@ -690,7 +690,7 @@ shell_path
     ;
 
 shell_script
-    : 'shellScript' '=' QUOTED_STRING ';'
+    : 'shellScript' '=' (QUOTED_STRING|NON_QUOTED_STRING) ';'
     ;
 
 show_env_vars_in_log


### PR DESCRIPTION
This pull request adds support for unquoted `shellScript` values, similar to what is covered in https://github.com/Karumi/Kin/pull/41.

A test has not been added nor have the grammar files been compiled as there are unmerged changes to these files.
