### PR TITLE
Add GitHub Actions to compile ANTLR grammar

### DIFF
--- a/.github/workflows/commit-grammar.yml
+++ b/.github/workflows/commit-grammar.yml
@@ -1,0 +1,34 @@
+name: Commit Grammar
+
+on:
+  push:
+    branches: [ master ]
+    paths: [ kin/grammar/PBXProj.g4 ]
+
+jobs:
+  commit_grammar:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Download ANTLR 4.6
+        working-directory: /tmp
+        run: |
+          wget https://www.antlr.org/download/antlr-4.6-complete.jar
+      - name: Update grammar
+        working-directory: kin/grammar
+        run: |
+          java -jar /tmp/antlr-4.6-complete.jar PBXProj.g4 -Dlanguage=Python2
+      - name: Commit changes
+        run: |
+          git add kin/grammar
+          git status
+          if [ "$(git status --porcelain)" ]; then
+            git config --global user.email "actions@users.noreply.github.com"
+            git config --global user.name "Kin grammar bot"
+            git commit -m "Update grammar"
+            git push
+          fi

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Python package
+name: Python Package
 
 on:
   push:
@@ -10,7 +10,32 @@ on:
     branches: [ master ]
 
 jobs:
+  update_grammar:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Download ANTLR 4.6
+        working-directory: /tmp
+        run: |
+          wget https://www.antlr.org/download/antlr-4.6-complete.jar
+      - name: Generate grammar
+        working-directory: kin/grammar
+        run: |
+          java -jar /tmp/antlr-4.6-complete.jar PBXProj.g4 -Dlanguage=Python2
+      - name: Upload grammar
+        uses: actions/upload-artifact@master
+        with:
+          name: grammar
+          path: kin/grammar
+
   build:
+    needs: update_grammar
 
     runs-on: ubuntu-latest
     strategy:
@@ -19,6 +44,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Download grammar
+      uses: actions/download-artifact@master
+      with:
+        name: grammar
+        path: kin/grammar
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:

--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ The updated files can optionally be copied with this command for testing:
 cp * path/to/site-packages/kin/grammar/
 ```
 
-To run tests, first install the current version of kin by running `pip install .`. Then you can execute `./tests/tester.py` to run all the scenarios we created.
+Only the `PBXProj.g4` file needs to be committed, GitHub Actions will produce the compiled grammar files.
 
-Keep in mind that your PRs **must** be validated by Travis-CI.
+To run tests, first install the current version of kin by running `pip install .`. Then you can execute `./tests/tester.py` to run all the scenarios we created.
 
 License
 -------


### PR DESCRIPTION
This pull request uses GitHub Actions to produce the compiled ANTLR grammar files, it does two things:

- Compiles the `PBXProj.g4` file before the tests are run for open pull requests.
- Commits any grammar changes after a pull request is merged.

These changes allow multiple pull requests to be open without causing conflicts. The compiled grammar files can still be committed, unless they have been generated incorrectly no commits will be made.

It may be worth looking into making the compiled files ignored and force committing them via GitHub Actions, this is beyond the scope of this pull request though.