### PR TITLE
Check grammar changes on every commit

### DIFF
--- a/.github/workflows/commit-grammar.yml
+++ b/.github/workflows/commit-grammar.yml
@@ -3,7 +3,6 @@ name: Commit Grammar
 on:
   push:
     branches: [ master ]
-    paths: [ kin/grammar/PBXProj.g4 ]
 
 jobs:
   commit_grammar:


### PR DESCRIPTION
This pull request checks if the grammar files need updating on every commit to the `master` branch instead of just checking when `kin/grammar/PBXProj.g4` is modified.

There is a concurrency issue affecting multiple commits with changes to the `kin/grammar/PBXProj.g4` file. Earlier commits will fail to push as expected but the last one should succeed. The problem is if the final commit does not contain grammar changes:

![PixelSnap 2021-03-23 at 21 24 10@2x](https://user-images.githubusercontent.com/2276355/112213406-56512c80-8c1e-11eb-9371-b612bf0e2f28.png)
