### PR TITLE
Change PBXProject attribute order

### DIFF
--- a/kin/grammar/PBXProj.g4
+++ b/kin/grammar/PBXProj.g4
@@ -685,11 +685,11 @@ plist_structure_definition_identifier
 
 attributes
     : 'attributes' '=' '{'
+        build_targets_in_parallel?
         class_prefix?
         default_build_system_type_for_workspace?
         last_swift_migration?
         last_swift_update_check?
-        build_targets_in_parallel?
         last_testing_upgrade_check?
         last_upgrade_check?
         organization_name?

--- a/tests/ok/pbxproject.project.pbxproj
+++ b/tests/ok/pbxproject.project.pbxproj
@@ -1,0 +1,341 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 53;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		55209BC426EA8E5E0023BC26 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55209BC326EA8E5E0023BC26 /* AppDelegate.swift */; };
+		55209BC626EA8E5E0023BC26 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55209BC526EA8E5E0023BC26 /* ViewController.swift */; };
+		55209BC826EA8E600023BC26 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 55209BC726EA8E600023BC26 /* Assets.xcassets */; };
+		55209BCB26EA8E600023BC26 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 55209BC926EA8E600023BC26 /* Main.storyboard */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		55209BC026EA8E5E0023BC26 /* PBXProjectOrderTest.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PBXProjectOrderTest.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		55209BC326EA8E5E0023BC26 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		55209BC526EA8E5E0023BC26 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		55209BC726EA8E600023BC26 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		55209BCA26EA8E600023BC26 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		55209BCC26EA8E600023BC26 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		55209BCD26EA8E600023BC26 /* PBXProjectOrderTest.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = PBXProjectOrderTest.entitlements; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		55209BBD26EA8E5E0023BC26 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		55209BB726EA8E5E0023BC26 = {
+			isa = PBXGroup;
+			children = (
+				55209BC226EA8E5E0023BC26 /* PBXProjectOrderTest */,
+				55209BC126EA8E5E0023BC26 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		55209BC126EA8E5E0023BC26 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				55209BC026EA8E5E0023BC26 /* PBXProjectOrderTest.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		55209BC226EA8E5E0023BC26 /* PBXProjectOrderTest */ = {
+			isa = PBXGroup;
+			children = (
+				55209BC326EA8E5E0023BC26 /* AppDelegate.swift */,
+				55209BC526EA8E5E0023BC26 /* ViewController.swift */,
+				55209BC726EA8E600023BC26 /* Assets.xcassets */,
+				55209BC926EA8E600023BC26 /* Main.storyboard */,
+				55209BCC26EA8E600023BC26 /* Info.plist */,
+				55209BCD26EA8E600023BC26 /* PBXProjectOrderTest.entitlements */,
+			);
+			path = PBXProjectOrderTest;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		55209BBF26EA8E5E0023BC26 /* PBXProjectOrderTest */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 55209BD026EA8E600023BC26 /* Build configuration list for PBXNativeTarget "PBXProjectOrderTest" */;
+			buildPhases = (
+				55209BBC26EA8E5E0023BC26 /* Sources */,
+				55209BBD26EA8E5E0023BC26 /* Frameworks */,
+				55209BBE26EA8E5E0023BC26 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = PBXProjectOrderTest;
+			productName = PBXProjectOrderTest;
+			productReference = 55209BC026EA8E5E0023BC26 /* PBXProjectOrderTest.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		55209BB826EA8E5E0023BC26 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = YES;
+				CLASSPREFIX = Test;
+				DefaultBuildSystemTypeForWorkspace = Latest;
+				LastSwiftMigration = 1250;
+				LastSwiftUpdateCheck = 1250;
+				LastTestingUpgradeCheck = 1250;
+				LastUpgradeCheck = 1250;
+				ORGANIZATIONNAME = Test;
+				TargetAttributes = {
+					55209BBF26EA8E5E0023BC26 = {
+						CreatedOnToolsVersion = 12.5.1;
+					};
+				};
+			};
+			buildConfigurationList = 55209BBB26EA8E5E0023BC26 /* Build configuration list for PBXProject "PBXProjectOrderTest" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 55209BB726EA8E5E0023BC26;
+			productRefGroup = 55209BC126EA8E5E0023BC26 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				55209BBF26EA8E5E0023BC26 /* PBXProjectOrderTest */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		55209BBE26EA8E5E0023BC26 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				55209BC826EA8E600023BC26 /* Assets.xcassets in Resources */,
+				55209BCB26EA8E600023BC26 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		55209BBC26EA8E5E0023BC26 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				55209BC626EA8E5E0023BC26 /* ViewController.swift in Sources */,
+				55209BC426EA8E5E0023BC26 /* AppDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		55209BC926EA8E600023BC26 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				55209BCA26EA8E600023BC26 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		55209BCE26EA8E600023BC26 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 11.3;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		55209BCF26EA8E600023BC26 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 11.3;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+			};
+			name = Release;
+		};
+		55209BD126EA8E600023BC26 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = PBXProjectOrderTest/PBXProjectOrderTest.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = 6M5BCW6QH8;
+				ENABLE_HARDENED_RUNTIME = YES;
+				INFOPLIST_FILE = PBXProjectOrderTest/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.dnicolson.PBXProjectOrderTest;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		55209BD226EA8E600023BC26 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = PBXProjectOrderTest/PBXProjectOrderTest.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = 6M5BCW6QH8;
+				ENABLE_HARDENED_RUNTIME = YES;
+				INFOPLIST_FILE = PBXProjectOrderTest/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.dnicolson.PBXProjectOrderTest;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		55209BBB26EA8E5E0023BC26 /* Build configuration list for PBXProject "PBXProjectOrderTest" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				55209BCE26EA8E600023BC26 /* Debug */,
+				55209BCF26EA8E600023BC26 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		55209BD026EA8E600023BC26 /* Build configuration list for PBXNativeTarget "PBXProjectOrderTest" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				55209BD126EA8E600023BC26 /* Debug */,
+				55209BD226EA8E600023BC26 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 55209BB826EA8E5E0023BC26 /* Project object */;
+}


### PR DESCRIPTION
This pull request changes the order of the `BuildIndependentTargetsInParallel` attribute in the PBXProject object. Tested with a new project on Xcode 12.5.1 (12E507).